### PR TITLE
Fix sidebar menu scrolling for smaller viewport heights

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -101,7 +101,7 @@ export default function Sidebar({ isOpen, onToggle }: SidebarProps) {
 
       {/* Sidebar */}
       <div className={`
-        fixed left-0 top-0 h-full w-64 bg-gray-900 text-white z-40 transform transition-transform duration-300 ease-in-out
+        fixed left-0 top-0 h-full w-64 bg-gray-900 text-white z-40 transform transition-transform duration-300 ease-in-out overflow-y-auto
         ${isOpen ? 'translate-x-0' : '-translate-x-full'}
         lg:translate-x-0
       `}>


### PR DESCRIPTION
- Add overflow-y-auto to sidebar container to enable scrolling
- Resolves menu items being cut off on smaller screens
- Maintains responsive behavior and mobile functionality
- All 18 menu items now accessible via scrolling when needed