### PR TITLE
Add comprehensive password reset functionality for administrative users

### DIFF
--- a/src/app/api/usuarios/reset-password/route.ts
+++ b/src/app/api/usuarios/reset-password/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+import { authenticateWithPermission, createSuccessResponse, createErrorResponse } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-helpers'
+import { z } from 'zod'
+import { supabase } from '@/lib/supabase'
+
+const resetPasswordSchema = z.object({
+  userId: z.string().min(1, 'ID do usuário é obrigatório'),
+  newPassword: z.string().min(6, 'Nova senha deve ter pelo menos 6 caracteres')
+})
+
+export const POST = withErrorHandler(async function POST(request: NextRequest) {
+  await authenticateWithPermission('usuarios', 'admin')
+
+  const body = await request.json()
+  const { userId, newPassword } = resetPasswordSchema.parse(body)
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  
+  const isDevMode = !supabaseUrl || !supabaseKey || 
+                    supabaseUrl === '' || supabaseKey === '' ||
+                    supabaseUrl.includes('placeholder') || 
+                    supabaseKey.includes('placeholder')
+
+  if (isDevMode) {
+    return createSuccessResponse({
+      message: `Senha seria alterada para o usuário ${userId} (modo desenvolvimento)`
+    })
+  }
+
+  try {
+    const { error } = await supabase.auth.admin.updateUserById(userId, {
+      password: newPassword
+    })
+
+    if (error) {
+      return createErrorResponse(error.message, 400)
+    }
+
+    return createSuccessResponse({
+      message: 'Senha redefinida com sucesso'
+    })
+  } catch (error) {
+    console.error('Error resetting password:', error)
+    return createErrorResponse('Erro interno do servidor', 500)
+  }
+})

--- a/src/app/api/usuarios/send-password-reset/route.ts
+++ b/src/app/api/usuarios/send-password-reset/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server'
+import { authenticateWithPermission, createSuccessResponse, createErrorResponse } from '@/lib/auth'
+import { withErrorHandler } from '@/lib/api-helpers'
+import { z } from 'zod'
+import { supabase } from '@/lib/supabase'
+
+const sendPasswordResetSchema = z.object({
+  email: z.string().email('Email inválido')
+})
+
+export const POST = withErrorHandler(async function POST(request: NextRequest) {
+  await authenticateWithPermission('usuarios', 'admin')
+
+  const body = await request.json()
+  const { email } = sendPasswordResetSchema.parse(body)
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  
+  const isDevMode = !supabaseUrl || !supabaseKey || 
+                    supabaseUrl === '' || supabaseKey === '' ||
+                    supabaseUrl.includes('placeholder') || 
+                    supabaseKey.includes('placeholder')
+
+  if (isDevMode) {
+    return createSuccessResponse({
+      message: `Email de redefinição seria enviado para ${email} (modo desenvolvimento)`
+    })
+  }
+
+  try {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/auth/reset-password`
+    })
+
+    if (error) {
+      return createErrorResponse(error.message, 400)
+    }
+
+    return createSuccessResponse({
+      message: `Email de redefinição enviado para ${email}`
+    })
+  } catch (error) {
+    console.error('Error sending password reset email:', error)
+    return createErrorResponse('Erro interno do servidor', 500)
+  }
+})


### PR DESCRIPTION
- Implement email-based password reset via Supabase Admin API
- Add password reset modal with email option in users management interface
- Create /api/usuarios/send-password-reset endpoint for admin-only email reset
- Create /api/usuarios/reset-password endpoint for direct password changes
- Add proper authentication and validation with admin permission checks
- Support both development and production modes with appropriate fallbacks
- Integrate seamlessly with existing user management system

Resolves administrative password management requirements with role-based access control.