### PR TITLE
Fix infinite loop in auditoria page causing 500 error spam

### DIFF
--- a/src/app/dashboard/auditoria/page.tsx
+++ b/src/app/dashboard/auditoria/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import DashboardLayout from '@/components/layout/DashboardLayout'
 import { FileText } from 'lucide-react'
 
@@ -25,7 +25,7 @@ export default function AuditoriaPage() {
   const [filtroModulo, setFiltroModulo] = useState('')
   const [filtroAcao, setFiltroAcao] = useState('')
 
-  const fetchAcoes = async () => {
+  const fetchAcoes = useCallback(async () => {
     try {
       const params = new URLSearchParams()
       if (filtroModulo) params.append('modulo', filtroModulo)
@@ -41,11 +41,11 @@ export default function AuditoriaPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [filtroModulo, filtroAcao])
 
   useEffect(() => {
     fetchAcoes()
-  }, [filtroModulo, filtroAcao, fetchAcoes])
+  }, [fetchAcoes])
 
   const getAcaoColor = (acao: string) => {
     switch (acao) {


### PR DESCRIPTION
- Wrap fetchAcoes function in useCallback to prevent infinite re-renders
- Fix useEffect dependency array to stop continuous API calls
- Resolves 500 error loop reported after Phase 3 modernization