### PR TITLE
Remove URL tooltips from sidebar module icons

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -110,6 +110,7 @@ export default function Sidebar({ isOpen, onToggle }: SidebarProps) {
                   <Link
                     key={item.href}
                     href={item.href}
+                    title=""
                     onClick={() => {
                       // Close mobile menu when clicking a link
                       if (window.innerWidth < 1024) {


### PR DESCRIPTION
- Add title='' attribute to Link components in Sidebar.tsx
- Prevents browser default behavior of showing URL tooltips on hover
- Maintains all navigation functionality while improving UX