### PR TITLE
Fix mobile UI issues: header text truncation and page overflow

### DIFF
--- a/src/app/dashboard/alertas/page.tsx
+++ b/src/app/dashboard/alertas/page.tsx
@@ -203,28 +203,30 @@ export default function AlertasPage() {
   return (
     <DashboardLayout>
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div className="flex items-center">
             <div className="p-2 bg-gradient-to-br from-orange-100 to-orange-200 rounded-xl mr-3 transform transition-transform duration-200 hover:scale-110">
               <Bell className="h-6 w-6 text-orange-600" />
             </div>
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-slate-800 to-slate-600 bg-clip-text text-transparent">Configuração de Alertas</h1>
+            <h1 className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-slate-800 to-slate-600 bg-clip-text text-transparent">Configuração de Alertas</h1>
           </div>
-          <div className="flex space-x-3">
+          <div className="flex flex-col sm:flex-row gap-2 sm:gap-3">
             <button 
               onClick={processarAlertas}
               disabled={loading}
-              className="bg-gradient-to-r from-green-500 to-green-600 text-white px-6 py-3 rounded-xl hover:from-green-600 hover:to-green-700 flex items-center shadow-lg hover:shadow-xl transform transition-all duration-200 hover:scale-105 hover:-translate-y-0.5 group disabled:opacity-50"
+              className="bg-gradient-to-r from-green-500 to-green-600 text-white px-4 py-2 sm:px-6 sm:py-3 rounded-xl hover:from-green-600 hover:to-green-700 flex items-center justify-center shadow-lg hover:shadow-xl transform transition-all duration-200 hover:scale-105 hover:-translate-y-0.5 group disabled:opacity-50"
             >
-              <Settings className="h-5 w-5 mr-2 transition-transform duration-200 group-hover:rotate-90" />
-              Processar Alertas
+              <Settings className="h-4 w-4 sm:h-5 sm:w-5 mr-2 transition-transform duration-200 group-hover:rotate-90" />
+              <span className="hidden sm:inline">Processar Alertas</span>
+              <span className="sm:hidden">Processar</span>
             </button>
             <button 
               onClick={handleOpenModal}
-              className="bg-gradient-to-r from-orange-500 to-orange-600 text-white px-6 py-3 rounded-xl hover:from-orange-600 hover:to-orange-700 flex items-center shadow-lg hover:shadow-xl transform transition-all duration-200 hover:scale-105 hover:-translate-y-0.5 group"
+              className="bg-gradient-to-r from-orange-500 to-orange-600 text-white px-4 py-2 sm:px-6 sm:py-3 rounded-xl hover:from-orange-600 hover:to-orange-700 flex items-center justify-center shadow-lg hover:shadow-xl transform transition-all duration-200 hover:scale-105 hover:-translate-y-0.5 group"
             >
-              <Plus className="h-5 w-5 mr-2 transition-transform duration-200 group-hover:rotate-90" />
-              Nova Configuração
+              <Plus className="h-4 w-4 sm:h-5 sm:w-5 mr-2 transition-transform duration-200 group-hover:rotate-90" />
+              <span className="hidden sm:inline">Nova Configuração</span>
+              <span className="sm:hidden">Nova</span>
             </button>
           </div>
         </div>

--- a/src/app/dashboard/usuarios/page.tsx
+++ b/src/app/dashboard/usuarios/page.tsx
@@ -198,27 +198,29 @@ export default function UsuariosPage() {
   return (
     <DashboardLayout>
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div className="flex items-center">
             <div className="p-2 bg-gradient-to-br from-orange-100 to-orange-200 rounded-xl mr-3 transform transition-transform duration-200 hover:scale-110">
               <Users className="h-6 w-6 text-orange-600" />
             </div>
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-slate-800 to-slate-600 bg-clip-text text-transparent">Gerenciamento de Usuários</h1>
+            <h1 className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-slate-800 to-slate-600 bg-clip-text text-transparent">Gerenciamento de Usuários</h1>
           </div>
-          <div className="flex space-x-3">
+          <div className="flex flex-col sm:flex-row gap-2 sm:gap-3">
             <button
               onClick={() => setShowInviteModal(true)}
-              className="inline-flex items-center px-4 py-2 border border-slate-300 text-sm font-medium rounded-xl text-slate-700 bg-white hover:bg-slate-50 transition-all duration-200 hover:scale-[1.02] transform"
+              className="inline-flex items-center justify-center px-3 py-2 sm:px-4 border border-slate-300 text-sm font-medium rounded-xl text-slate-700 bg-white hover:bg-slate-50 transition-all duration-200 hover:scale-[1.02] transform"
             >
               <Mail className="h-4 w-4 mr-2" />
-              Convidar Usuário
+              <span className="hidden sm:inline">Convidar Usuário</span>
+              <span className="sm:hidden">Convidar</span>
             </button>
             <button
               onClick={() => setShowCreateModal(true)}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-xl text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 transition-all duration-200 hover:scale-[1.02] transform"
+              className="inline-flex items-center justify-center px-3 py-2 sm:px-4 border border-transparent text-sm font-medium rounded-xl text-white bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 transition-all duration-200 hover:scale-[1.02] transform"
             >
               <Plus className="h-4 w-4 mr-2" />
-              Criar Usuário
+              <span className="hidden sm:inline">Criar Usuário</span>
+              <span className="sm:hidden">Criar</span>
             </button>
           </div>
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -117,3 +117,20 @@ body {
 .animate-shrink {
   animation: shrink linear forwards;
 }
+
+/* Mobile header spacing */
+@media (max-width: 640px) {
+  .mobile-header-spacing {
+    margin-left: 3rem; /* Space for hamburger button */
+  }
+  
+  .mobile-button-text {
+    font-size: 0.875rem;
+    padding: 0.5rem 0.75rem;
+  }
+  
+  .mobile-title {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -78,7 +78,7 @@ export default function Header({ onGlobalSearch, onToggleWorkflow }: HeaderProps
   return (
     <header className="fixed top-0 left-0 lg:left-64 right-0 h-16 bg-white/70 backdrop-blur-xl border-b border-slate-200/40 z-30 shadow-lg shadow-slate-200/20 transition-all duration-300">
       <div className="flex items-center justify-between h-full px-6">
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center space-x-4 ml-12 lg:ml-0">
           <h1 className="text-base font-bold bg-gradient-to-r from-slate-800 to-slate-600 bg-clip-text text-transparent hidden md:block">
             {currentDateTime.toLocaleDateString('pt-BR', {
               weekday: 'long',

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -72,7 +72,7 @@ export default function Sidebar({ isOpen, onToggle }: SidebarProps) {
       {/* Mobile menu button */}
       <button
         onClick={onToggle}
-        className="lg:hidden fixed top-4 left-4 z-50 p-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-105"
+        className="lg:hidden fixed top-4 left-4 z-50 p-2 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-105"
         aria-label="Toggle menu"
       >
         {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}


### PR DESCRIPTION
- Adjust header layout to provide proper spacing for mobile text (ml-12 lg:ml-0)
- Make User Management page buttons responsive with flex-col sm:flex-row layout
- Make Alert Configuration page buttons responsive with flex-col sm:flex-row layout
- Add shorter button text for mobile (e.g., 'Convidar Usuário' → 'Convidar')
- Add mobile-specific CSS utilities for better responsive behavior
- Fix horizontal overflow on mobile devices by stacking buttons vertically
- Ensure 'FichaChef' header text displays fully without hamburger menu overlap