### PR TITLE
fix: remove remaining conditional render blocks preventing useEffect …

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,12 +35,5 @@ export default function Home() {
     }
   }, [router, user, loading, isConfigured])
 
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-gray-900">FichaChef</h1>
-        <p className="text-gray-600">Redirecionando...</p>
-      </div>
-    </div>
-  )
+  return null
 }

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -60,14 +60,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   // ✅ VERIFICAÇÃO: Se Supabase configurado mas sem usuário, não renderizar
   if (isConfigured && !user) {
-    return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
-        <div className="text-center">
-          <LoadingSpinner size="lg" className="mx-auto mb-4" />
-          <p className="text-slate-600 font-medium">Redirecionando para login...</p>
-        </div>
-      </div>
-    )
+    return null
   }
 
   // ✅ RENDERIZAÇÃO: Layout principal


### PR DESCRIPTION
…execution

- Remove conditional render from page.tsx that returns 'Redirecionando...' screen
- Remove conditional render from DashboardLayout.tsx that returns 'Redirecionando para login...' screen
- Allow useEffect hooks to execute properly when user state changes after login
- Fix login redirect stuck issue by relying purely on useEffect logic