### PR TITLE
Investigate and fix product display bug

### DIFF
--- a/src/app/api/produtos/route.ts
+++ b/src/app/api/produtos/route.ts
@@ -9,7 +9,6 @@ import {
 import { logUserAction, extractRequestMetadata } from '@/lib/permissions'
 import { withErrorHandler } from '@/lib/api-helpers'
 import { produtoSchema } from '@/lib/validations'
-import { withTempUserHandling } from '@/lib/temp-user-utils'
 
 // Autenticação simples (compatível com Insumos)
 async function getAuthenticatedUser(): Promise<{ id: string; email: string } | null> {
@@ -29,29 +28,27 @@ export const GET = withErrorHandler(async function GET() {
     return createValidationErrorResponse('Não autorizado')
   }
 
-  return withTempUserHandling(user.id, 'produtos', async () => {
-    const produtos = await withConnectionHealthCheck(async () => {
-      return await withDatabaseRetry(async () => {
-        return await prisma.produto.findMany({
-          where: { userId: user.id },
-          include: {
-            produtoFichas: {
-              include: {
-                fichaTecnica: {
-                  include: {
-                    ingredientes: { include: { insumo: true } }
-                  }
+  const produtos = await withConnectionHealthCheck(async () => {
+    return await withDatabaseRetry(async () => {
+      return await prisma.produto.findMany({
+        where: { userId: user.id },
+        include: {
+          produtoFichas: {
+            include: {
+              fichaTecnica: {
+                include: {
+                  ingredientes: { include: { insumo: true } }
                 }
               }
             }
-          },
-          orderBy: { nome: 'asc' },
-        })
+          }
+        },
+        orderBy: { nome: 'asc' },
       })
     })
-
-    return createSuccessResponse(produtos)
   })
+
+  return createSuccessResponse(produtos)
 })
 
 export const POST = withErrorHandler(async function POST(request: NextRequest) {


### PR DESCRIPTION
Remove `withTempUserHandling` from GET /api/produtos to correctly display products for all users.

The `withTempUserHandling` helper was causing the GET /api/produtos route to return an empty array when the user was `temp-prod-user` (production/fallback mode), preventing saved products from being displayed on the frontend.

---
<a href="https://cursor.com/background-agent?bcId=bc-17181148-b5c4-4f24-8497-724ad3f6f463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17181148-b5c4-4f24-8497-724ad3f6f463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

