### PR TITLE
Investigar erros 401 no dashboard

### DIFF
--- a/src/app/api/auth/sync/route.ts
+++ b/src/app/api/auth/sync/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+function getAuthCookieName(): string {
+  const projectRef = process.env.NEXT_PUBLIC_SUPABASE_URL?.split('//')[1]?.split('.')[0]
+  return `sb-${projectRef}-auth-token`
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization') || ''
+    const hasBearer = authHeader.startsWith('Bearer ')
+    const body = await request.json().catch(() => ({})) as {
+      refresh_token?: string
+      expires_at?: number
+      token_type?: string
+      user?: unknown
+    }
+
+    const accessToken = hasBearer ? authHeader.substring(7) : undefined
+    const refreshToken = body.refresh_token
+
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Missing access token' }, { status: 400 })
+    }
+
+    const cookieName = getAuthCookieName()
+
+    const payload = {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      expires_at: body.expires_at,
+      token_type: body.token_type || 'bearer',
+      user: body.user || null,
+    }
+
+    const response = NextResponse.json({ ok: true })
+
+    response.cookies.set(cookieName, JSON.stringify(payload), {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 7, // 7 dias
+      path: '/',
+    })
+
+    return response
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to sync auth' }, { status: 500 })
+  }
+}
+
+export async function DELETE() {
+  const cookieName = getAuthCookieName()
+  const response = NextResponse.json({ ok: true })
+  response.cookies.set(cookieName, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 0,
+    path: '/',
+  })
+  return response
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ export default function Header({ onGlobalSearch, onToggleWorkflow }: HeaderProps
 
   const fetchNotificacoes = useCallback(async () => {
     try {
-      const response = await fetch('/api/notificacoes?lida=false')
+      const response = await fetch('/api/notificacoes?lida=false', { credentials: 'include' })
       if (response.ok) {
         const data = await response.json()
         setNotificacoes(data)
@@ -59,7 +59,8 @@ export default function Header({ onGlobalSearch, onToggleWorkflow }: HeaderProps
       await fetch('/api/notificacoes', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ids, lida: true })
+        body: JSON.stringify({ ids, lida: true }),
+        credentials: 'include'
       })
       fetchNotificacoes()
     } catch (error) {


### PR DESCRIPTION
Synchronize Supabase session cookie to resolve 401 errors on API routes for authenticated users.

Client-side authentication was working, but server-side API routes were failing with 401 because the Supabase HTTP-only session cookie, required by `createServerClient` on the server, was not being set. This PR introduces a mechanism to explicitly sync the client's session token to a server-side HTTP-only cookie, ensuring API routes correctly recognize authenticated users.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb7cf39d-fde8-45bb-a7ec-24a8f0c59ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb7cf39d-fde8-45bb-a7ec-24a8f0c59ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

