### PR TITLE
Corrigir loop de carregamento após refresh

### DIFF
--- a/src/components/providers/SupabaseProvider.tsx
+++ b/src/components/providers/SupabaseProvider.tsx
@@ -243,6 +243,8 @@ export function SupabaseProvider({ children }: { children: React.ReactNode }) {
               setUserRole(null)
               try { await fetch('/api/auth/sync', { method: 'DELETE', credentials: 'include' }) } catch {}
             }
+            // ✅ Garantir que a inicialização seja marcada como concluída mesmo que o evento dispare antes do initializeAuth
+            setIsInitialized(true)
             setLoading(false)
           }
         }


### PR DESCRIPTION
Fixes a race condition in `SupabaseProvider` to prevent infinite loading after refresh by ensuring `isInitialized` is set correctly on auth state change.

The `ROOT` component was getting stuck in "Aguardando inicialização do provider..." because the `onAuthStateChange` event could fire and update the user state before the `initializeAuth` process fully completed, but `isInitialized` was not being set to `true` in this specific path. This change ensures `isInitialized` is always set when the auth state is confirmed, allowing the application to proceed.

---
<a href="https://cursor.com/background-agent?bcId=bc-e926ce19-c1d1-4474-a137-5f580c73e127">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e926ce19-c1d1-4474-a137-5f580c73e127">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

