### PR TITLE
Corrigir loop de carregamento do sistema

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -13,7 +13,7 @@ interface DashboardLayoutProps {
 
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const router = useRouter()
-  const { user, loading, isConfigured } = useSupabase()
+  const { user, loading, isConfigured, isInitialized } = useSupabase()
   const [isHydrated, setIsHydrated] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
@@ -22,12 +22,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     setIsHydrated(true)
   }, [])
 
-  // ✅ CORRIGIDO: Redirecionamento apenas após hidratação e carregamento
+  // ✅ CORRIGIDO: Redirecionamento apenas após hidratação e inicialização
   useEffect(() => {
-    console.log('🔍 DashboardLayout useEffect:', { isHydrated, loading, isConfigured, user: !!user, userEmail: user?.email })
+    console.log('🔍 DashboardLayout useEffect:', { isHydrated, isInitialized, loading, isConfigured, user: !!user, userEmail: user?.email })
     
-    if (!isHydrated || loading) {
-      console.log('🚫 DashboardLayout: Aguardando hidratação ou loading')
+    if (!isHydrated || !isInitialized) {
+      console.log('🚫 DashboardLayout: Aguardando hidratação ou inicialização')
       return
     }
 
@@ -44,10 +44,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     } else if (user) {
       console.log('✅ DashboardLayout: Usuário autenticado, permitindo acesso ao dashboard:', user.email)
     }
-  }, [isHydrated, loading, isConfigured, user, router])
+  }, [isHydrated, isInitialized, loading, isConfigured, user, router])
 
-  // ✅ LOADING: Mostrar spinner durante hidratação ou carregamento
-  if (!isHydrated || loading) {
+  // ✅ LOADING: Mostrar spinner durante hidratação ou inicialização
+  if (!isHydrated || !isInitialized) {
     return (
       <div className="min-h-screen bg-slate-50 flex items-center justify-center">
         <div className="text-center">


### PR DESCRIPTION
Updates `DashboardLayout` to use `isInitialized` for rendering, resolving the infinite "Carregando sistema..." loop on reload.

The previous implementation relied on the `loading` flag, which also indicated ongoing role refreshes, causing the layout to block rendering even when the user was authenticated. Switching to `isInitialized` ensures the layout renders only after the provider is fully set up.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b04b092-92b9-41f8-8206-33305f856296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b04b092-92b9-41f8-8206-33305f856296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

