### PR TITLE
Debug layout error with service worker

### DIFF
--- a/src/components/providers/SupabaseProvider.tsx
+++ b/src/components/providers/SupabaseProvider.tsx
@@ -189,6 +189,11 @@ export function SupabaseProvider({ children }: { children: React.ReactNode }) {
       try {
         console.log('🔄 [PROVIDER] Inicializando autenticação...')
         
+        // ✅ Marcar inicialização iniciada imediatamente para destravar telas que aguardam esse flag
+        if (mounted) {
+          setIsInitialized(true)
+        }
+        
         if (!isConfigured) {
           console.log('🔧 [PROVIDER] Supabase não configurado - modo desenvolvimento')
           setIsInitialized(true)


### PR DESCRIPTION
Set `isInitialized` to true earlier in SupabaseProvider to prevent the app from getting stuck waiting for initialization.

The previous behavior caused the root component to wait for `isInitialized` to become true, even after authentication had started and a user was identified. By setting `isInitialized` immediately upon starting authentication, the root component can proceed to check the `loading` state and correctly handle redirects, resolving the "Aguardando inicialização do provider..." loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-51f06c88-b5ba-4590-a4dc-80836ce1bd7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51f06c88-b5ba-4590-a4dc-80836ce1bd7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

