### PR TITLE
Build nextjs app with type checking

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ interface HeaderProps {
 }
 
 export default function Header({ onGlobalSearch, onToggleWorkflow }: HeaderProps = {}) {
-  const { user, userRole, signOut } = useSupabase() as any
+  const { user, userRole, signOut } = useSupabase()
   const router = useRouter()
   const [notificacoes, setNotificacoes] = useState<Notificacao[]>([])
   const [showNotifications, setShowNotifications] = useState(false)


### PR DESCRIPTION
Remove `as any` cast from `useSupabase()` to resolve `@typescript-eslint/no-explicit-any` build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e3a3873-37fe-41c6-9fdc-ac51287e9f91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e3a3873-37fe-41c6-9fdc-ac51287e9f91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

