### PR TITLE
Build nextjs app with type error

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -85,7 +85,7 @@ export default function Header({ onGlobalSearch, onToggleWorkflow }: HeaderProps
     .split(/\s+/)
     .filter(Boolean)
     .slice(0, 2)
-    .map(word => word[0]?.toUpperCase())
+    .map((word: string) => (word[0] ?? '').toUpperCase())
     .join('') || 'US'
 
   return (


### PR DESCRIPTION
Fixes TypeScript implicit 'any' error in Header component by explicitly typing map parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cd74e13-dbbb-4921-a978-1f5cd84ba215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cd74e13-dbbb-4921-a978-1f5cd84ba215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

