### PR TITLE
Fix left menu shortcut black screen

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -86,13 +86,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         </main>
       </div>
 
-      {/* ✅ Mobile Sidebar Overlay */}
-      {sidebarOpen && (
-        <div 
-          className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
-          onClick={() => setSidebarOpen(false)}
-        />
-      )}
+      {/* Overlay duplicado removido: o componente `Sidebar` já renderiza seu próprio overlay no mobile */}
     </div>
   )
 }


### PR DESCRIPTION
Remove duplicate mobile overlay in `DashboardLayout.tsx` to fix black screen when opening sidebar.

The `Sidebar` component already renders its own overlay; a second, identical overlay in `DashboardLayout` with the same z-index was causing the entire screen to turn black when the sidebar was opened on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4488c02-1926-4db6-ba17-c0c8dae3c775">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a4488c02-1926-4db6-ba17-c0c8dae3c775">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

